### PR TITLE
Accoding to

### DIFF
--- a/Ceph-RBD-Provisioner.yaml
+++ b/Ceph-RBD-Provisioner.yaml
@@ -63,12 +63,15 @@ kind: ServiceAccount
 metadata:
   name: rbd-provisioner
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rbd-provisioner
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: rbd-provisioner
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ the API
Version extensions/v1beta1 was deprecated and must be replaced by apps/v1.
And now is required the selector option.